### PR TITLE
update mixins.json

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,7 @@ plugins {
     id 'idea'
     id 'maven-publish'
     id "me.shedaniel.unified-publishing" version "0.1.+"
-    id 'net.neoforged.gradle.userdev' version '7.0.145'
-    id 'net.neoforged.gradle.mixin' version '7.0.145'
+    id 'net.neoforged.gradle.userdev' version '7.1.25'
 }
 
 tasks.named('wrapper', Wrapper).configure {
@@ -97,10 +96,6 @@ repositories {
     maven {
         url = "https://api.modrinth.com/maven"
     }
-}
-
-mixin {
-    config "${mod_id}.mixins.json"
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.daemon=false
 # check these on https://fabricmc.net/versions.html
 minecraft_version=1.21.1
 supported_version=1.21.1
-neo_version=21.1.115
+neo_version=21.1.228
 #neogradle.subsystems.parchment.minecraftVersion=1.21
 #neogradle.subsystems.parchment.mappingsVersion=2024.07.07
 # Mod Properties

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,5 +9,5 @@ pluginManagement {
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }

--- a/src/main/resources/autochefsdelight.mixins.json
+++ b/src/main/resources/autochefsdelight.mixins.json
@@ -1,8 +1,7 @@
 {
   "required": true,
   "package": "snownee.autochefsdelight.mixin",
-  "compatibilityLevel": "JAVA_8",
-  "refmap": "autochefsdelight.refmap.json",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
     "CookingPotBlockEntityMixin",
     "CookingPotRecipeMixin",
@@ -13,5 +12,7 @@
   "injectors": {
     "defaultRequire": 1
   },
-  "minVersion": "0.8"
+  "overwrites": {
+    "requireAnnotations": true
+  }
 }


### PR DESCRIPTION
Fixes #8 

I've tried to keep the changes to a minimum
- Updated to latest NeoGradle
- Updated to latest minor version of Gradle 8 (you could use Gradle 9, I just did not want to make a major change)
- Targets latest neoforge
- Updated mixins.json to the new template that both Fabric and Neo use, also made it target java_21 instead of 8 as is expected in 1.21.1

I will make a Fabric PR in a second