### PR TITLE
update mixins.json (fabric)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,9 @@
 plugins {
-    id 'fabric-loom' version '1.10-SNAPSHOT'
+    id 'net.fabricmc.fabric-loom-remap' version '1.16-SNAPSHOT'
     id 'maven-publish'
     id "me.shedaniel.unified-publishing" version "0.1.+"
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
-targetCompatibility = JavaVersion.VERSION_21
-
-archivesBaseName = project.archives_base_name
 version = project.minecraft_version + "-Fabric-" + project.mod_version
 group = project.maven_group
 var realVersion = project.mod_version + '+fabric'
@@ -108,9 +104,6 @@ dependencies {
 }
 
 loom {
-    mixin {
-        defaultRefmapName = "${project.mod_id}.refmap.json"
-    }
 
 //    accessWidenerPath = file("src/main/resources/${project.mod_id}.accesswidener")
 
@@ -151,6 +144,8 @@ java {
     // if it is present.
     // If you remove this line, sources will not be generated.
     // withSourcesJar()
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
-org.gradle.jvmargs=-Xmx3G
+org.gradle.jvmargs=-Xmx3G -Dfile.encoding=UTF8 -DsocksProxyHost=127.0.0.1 -DsocksProxyPort=1079
 org.gradle.daemon=false
 
 # Fabric Properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
-org.gradle.jvmargs=-Xmx3G -Dfile.encoding=UTF8 -DsocksProxyHost=127.0.0.1 -DsocksProxyPort=1079
+org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
 minecraft_version=1.21.1
 supported_version=1.21.1
-loader_version=0.16.4
+loader_version=0.19.2
 # Mod Properties
 mod_version=2.1.0
 release_type=beta
@@ -15,7 +15,7 @@ mod_id=autochefsdelight
 maven_group=snownee.autochefsdelight
 archives_base_name=AutochefsDelight
 # Dependencies
-fabric_version=0.103.0+1.21.1
+fabric_version=0.116.11+1.21.1
 cloth_config_version=15.0.130
 modmenu_version=11.0.2
 architectury_version=13.0.6

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/autochefsdelight.mixins.json
+++ b/src/main/resources/autochefsdelight.mixins.json
@@ -1,8 +1,7 @@
 {
 	"required": true,
 	"package": "snownee.autochefsdelight.mixin",
-	"compatibilityLevel": "JAVA_8",
-	"refmap": "autochefsdelight.refmap.json",
+	"compatibilityLevel": "JAVA_21",
 	"mixins": [
 		"CookingPotBlockEntityMixin",
 		"CookingPotRecipeMixin",
@@ -13,5 +12,7 @@
 	"injectors": {
 		"defaultRequire": 1
 	},
-	"minVersion": "0.8"
+  "overwrites": {
+    "requireAnnotations": true
+  }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,7 +19,7 @@
     "autochefsdelight.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.15",
+    "fabricloader": ">=0.19.2",
     "minecraft": ">=1.21 <=1.21.1",
     "farmersdelight": ">=1.21.1-3.0.3"
   },


### PR DESCRIPTION
Same as the Neoforge PR except i updated to Gradle 9 here
Fixes #8 on fabric 

I've tried to keep the changes to a minimum
- Updated to latest Fabric and Loom
- Updated to latest minor version of Gradle 9 (was forced by latest fabric)
- Targets latest Fabric API
- Updated mixins.json to the new template that both Fabric and Neo use, also made it target java_21 instead of 8 as is expected in 1.21.1